### PR TITLE
add xdebug to allow code-coverage

### DIFF
--- a/php-7-ci/Dockerfile
+++ b/php-7-ci/Dockerfile
@@ -6,7 +6,7 @@ FROM php:7-alpine
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 ADD install_composer.sh /tmp
-RUN apk add --update --no-cache git unzip wget zip \
+RUN apk add --update --no-cache autoconf g++ git make unzip wget zip \
     "libmcrypt-dev" "postgresql-dev" "libpq" && \
     docker-php-ext-install \
         mbstring \
@@ -16,9 +16,12 @@ RUN apk add --update --no-cache git unzip wget zip \
 
         # needed for forking processes in laravel queues as of Laravel 5.3
         pcntl && \
+    pecl install xdebug && \
+    docker-php-ext-enable xdebug && \
     /tmp/install_composer.sh && \
     composer global require hirak/prestissimo && \
     wget https://github.com/generationtux/par/releases/download/v0.0.2/par_linux_amd64 --quiet && \
     mv par_linux_amd64 par && \
     chmod +x ./par && \
-    mv ./par /usr/local/bin/
+    mv ./par /usr/local/bin/ && \
+    apk del autoconf g++ make unzip wget zip


### PR DESCRIPTION
Installed and enabled xdebug so that we can have code-coverage in ci. This required us to install some extras like autoconf, g++, and make, but we then realized that we could purge a few extra packages after the container build was in a usable state.

Size increased from ~52MB to ~117MB, I believe; must be done though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/generationtux/docker-images/27)
<!-- Reviewable:end -->
